### PR TITLE
Issue/upgrade clab support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.4.0 (?)
 Changes in this release:
+ - Fix support for clab>=0.31
  - Start using yang::NetconfResource instead of yang::Resource.
 
 # v 1.3.0 (2022-06-16)

--- a/src/pytest_inmanta_yang/fixtures.py
+++ b/src/pytest_inmanta_yang/fixtures.py
@@ -189,7 +189,16 @@ def clab_hosts(
     assert inspect.returncode == 0, stderr
     LOGGER.debug(stdout)
 
-    hosts = [ClabHost(**host) for host in json.loads(stdout)]
+    # The layout of the json body has changed in this PR (released in 0.31)
+    # https://github.com/srl-labs/containerlab/pull/887
+    # Prior to this, we had a list of dicts as payload. We now have a dict containing
+    # a "containers" key, which has as value the former list.
+    containers_list = json.loads(stdout)
+    if isinstance(containers_list, dict):
+        containers_list = containers_list["containers"]
+
+    hosts = [ClabHost(**host) for host in containers_list]
+
     yield [host.config(clab_workdir) for host in hosts]
 
     # Destroy the lab


### PR DESCRIPTION
# Description

In the following PR, clab has changed the layout of the json response to the inspect command: https://github.com/srl-labs/containerlab/pull/887 (clab>=0.31)
This breaks our clab_hosts fixture, this PR is a quick fix for this.

