### PR TITLE
Pin ncdiff to same version as the yang module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ lxml
 ncclient
 pyang==2.5.3
 pytest
-ncdiff>=20.10
+ncdiff~=20.10
 requests
 scrapli
 paramiko


### PR DESCRIPTION
# Description

In the different vendor's ci, the latest version of ncdiff is being installed instead of the one provided by the yang module.  This might, or might not be causing issues for juniper.  I am pinning the version here so that the version of ncdiff installed in the test venv is the one the handler expects.