### PR TITLE
Ignore namespace of filter element in get_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Changes in this release:
  - Fix support for clab>=0.31
  - Start using yang::NetconfResource instead of yang::Resource.
+ - Ignore filter namespace in get_config method
 
 # v 1.3.0 (2022-06-16)
 Changes in this release:

--- a/src/pytest_inmanta_yang/netconf_device_helper.py
+++ b/src/pytest_inmanta_yang/netconf_device_helper.py
@@ -186,7 +186,7 @@ class NetconfDeviceHelper(object):
         if filter is not None and isinstance(filter, str):
             filter = etree.fromstring(filter)
 
-        if filter is not None and not filter.tag == "filter":
+        if filter is not None and not etree.QName(filter).localname == "filter":
             root = etree.Element("filter")
             root.append(filter)
             filter = root


### PR DESCRIPTION
IOS XE requires filter element to have a namespace (`urn:ietf:params:xml:ns:netconf:base:1.0`). Current code will pack filter object in additional "filter" element without any namespace.

```
In [7]: z = etree.fromstring('<nc:filter xmlns:nc="foo"><bar/></nc:filter>')

In [8]: etree.QName(z).localname
Out[8]: 'filter'

In [9]: etree.QName(z).namespace
Out[9]: 'foo'

In [10]: x = etree.fromstring('<filter><bar/></filter>')

In [11]: etree.QName(x).localname
Out[11]: 'filter'

In [12]: etree.QName(x).namespace


In [16]: z.tag
Out[16]: '{foo}filter'
```