### PR TITLE
[FORMAT] fix line too long flake8 error

### DIFF
--- a/src/pytest_inmanta_yang/yang_test.py
+++ b/src/pytest_inmanta_yang/yang_test.py
@@ -148,8 +148,8 @@ class YangTest:
         return self._project.dryrun_resource(resource_type)
 
     def deploy(self, pre_dryrun: bool = True, post_dryrun: bool = True) -> None:
-        """Deploy the yang::NetconfResource in the model. By default it asserts that before the deploy there are dryrun changes and
-        after the deploy there are not dryrun changes.
+        """Deploy the yang::NetconfResource in the model. By default it asserts that before the deploy there are dryrun changes
+        and after the deploy there are not dryrun changes.
 
         This can be disabled and dryruns can be run with self.dryrun.
         """


### PR DESCRIPTION
Flake8 upper bound removal caused the following error to pop up :

```
src/pytest_inmanta_yang/yang_test.py:151:129: E501 line too long (131 > 128 characters)
```
