### PR TITLE
Use 'replace' operation in srlinux test model

### DIFF
--- a/docs/examples/nokia-srlinux-interface/model/_init.cf
+++ b/docs/examples/nokia-srlinux-interface/model/_init.cf
@@ -47,6 +47,7 @@ implementation basic_interface for Interface:
                 ),
             ),
         ),
+        comanaged=false,
     )
 end
 


### PR DESCRIPTION
The sequence of dryrun-deploy-dryrun makes the CI to fail. It happens because of missing "mtu" attribute in gnmi response. By setting `comanaged=false` we are using a `replace` operation, which changes the logic on how yang filter is built.

EDIT: this is a temporary workaround, further discussion will happen in related issue: https://code.inmanta.com/solutions/modules/yang/-/issues/112