### PR TITLE
Remove module specification from inmanta-dev-dependencies

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-inmanta-dev-dependencies[module]~=2.96
+inmanta-dev-dependencies~=2.96
 pytest-cov==4.1.0
 types-paramiko==3.3.0.2
 types-PyYAML==6.0.12.12


### PR DESCRIPTION
inmanta-dev-dependencies[module] just added the `pytest-inmanta` requirement. But we already have it pinned on requirements.txt 
I believe that was causing some conflicts with the version of `pytest-inmanta`. If we want to use the newest version of `pytest-inmanta` I think we should just change requirements.txt