### PR TITLE
Create default filter node with correct namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v 1.5.0 (?)
 Changes in this release:
+ - Create default filter node with correct namespace
 
 # v 1.4.0 (2024-02-20)
 Changes in this release:

--- a/src/pytest_inmanta_yang/netconf_device_helper.py
+++ b/src/pytest_inmanta_yang/netconf_device_helper.py
@@ -27,6 +27,7 @@ from ncclient.operations.lock import LockContext  # type: ignore
 from scrapli import Scrapli
 
 from pytest_inmanta_yang.const import (
+    NETCONF_NS_URN,
     VENDOR_CISCO,
     VENDOR_JUNIPER,
     VENDOR_NOKIA,
@@ -188,7 +189,7 @@ class NetconfDeviceHelper(object):
             filter = etree.fromstring(filter)
 
         if filter is not None and not etree.QName(filter).localname == "filter":
-            root = etree.Element("filter")
+            root = etree.Element(f"{{{NETCONF_NS_URN}}}filter")
             root.append(filter)
             filter = root
 


### PR DESCRIPTION
When value passed as `filter` attribute of `get_config` method was missing `filter` node at the top, everything was wrapped into newly created filter node. This node was missing default NETCONF namespace. It is an issue for Nokia SROS R23.

Request sent to a device in yang test:
```
> /home/user/ws/.venv39-yang/lib64/python3.9/site-packages/ncclient/operations/rpc.py(375)_request()
-> raise self._reply.error
(Pdb) self
<ncclient.operations.retrieve.GetConfig object at 0x7ff00f073670>
(Pdb) req
'<?xml version="1.0" encoding="UTF-8"?><nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:71154415-c414-487b-b7b7-96edd4bf54ec"><nc:get-config><nc:source><nc:running/></nc:source><filter><configure xmlns="urn:nokia.com:sros:ns:yang:sr:conf">\n    <router>\n        <router-name>Base</router-name><interface/></router></configure></filter></nc:get-config></nc:rpc>'
```