### PR TITLE
Bump minimal required python version to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
-## v2.0.0 - ?
+## v1.6.1 - ?
 
-- Bump minimal required python version to 3.12
 
 ## v1.6.0 - 2025-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v1.6.1 - ?
+## v2.0.0 - ?
 
+- Bump minimal required python version to 3.12
 
 ## v1.6.0 - 2025-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v1.6.1 - ?
+## v1.7.0 - ?
 
+- Bump minimal required python version to 3.12
 
 ## v1.6.0 - 2025-10-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-yang"
-version = "1.6.1"
+version = "1.7.0"
 description = "Common fixtures used in inmanta yang related modules"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -51,7 +51,7 @@ packages = { find = { where = ["src"] } }
 pytest_inmanta_yang = ["clab/srlinux.topology.yml", "py.typed"]
 
 [tool.bumpversion]
-current_version = "1.6.1.dev0"
+current_version = "1.7.0.dev0"
 tag = false
 commit = false
 parse = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-yang"
-version = "1.6.1"
+version = "2.0.0"
 description = "Common fixtures used in inmanta yang related modules"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 keywords = ["pytest", "inmanta", "yang"]
 authors = [{ name = "Inmanta", email = "code@inmanta.com" }]
@@ -18,7 +18,6 @@ classifiers = [
   "Framework :: Pytest",
   "Intended Audience :: Developers",
   "Topic :: Software Development :: Testing",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3 :: Only",
@@ -52,7 +51,7 @@ packages = { find = { where = ["src"] } }
 pytest_inmanta_yang = ["clab/srlinux.topology.yml", "py.typed"]
 
 [tool.bumpversion]
-current_version = "1.6.1.dev0"
+current_version = "2.0.0.dev0"
 tag = false
 commit = false
 parse = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-inmanta-yang"
-version = "2.0.0"
+version = "1.6.1"
 description = "Common fixtures used in inmanta yang related modules"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -51,7 +51,7 @@ packages = { find = { where = ["src"] } }
 pytest_inmanta_yang = ["clab/srlinux.topology.yml", "py.typed"]
 
 [tool.bumpversion]
-current_version = "2.0.0.dev0"
+current_version = "1.6.1.dev0"
 tag = false
 commit = false
 parse = """


### PR DESCRIPTION
As per [slack discussion](https://inmanta.slack.com/archives/CKRF0C8R3/p1776074154698879?thread_ts=1776069987.748719&cid=CKRF0C8R3).
Bumping minimal required python version to 3.12 now that iso7 is no longer supported.
This previous compatibility with iso7's python 3.11 was holding back the dependabot bumping of inmanta-dev-dependencies to v2.187.